### PR TITLE
Revise indexing error when creating HITs with multiple hit layout parameters

### DIFF
--- a/R/CreateHIT.R
+++ b/R/CreateHIT.R
@@ -242,7 +242,7 @@ CreateHIT <-
         args <- c(args, list(HITLayoutId = as.character(hitlayoutid)))
         if(!is.null(hitlayoutparameters)){
           for(i in 1:length(hitlayoutparameters)){
-            hitlayoutparameters[[1]] <- reticulate::dict(hitlayoutparameters[[1]] )
+            hitlayoutparameters[[i]] <- reticulate::dict(hitlayoutparameters[[i]] )
           }
           args <- c(args, list(HITLayoutParameters = hitlayoutparameters))
         }


### PR DESCRIPTION
- Modifies indexing to correctly format dictionaries when multiple hitlayoutparameters exist.