### PR TITLE
Add warning to CreateHIT.R

### DIFF
--- a/R/CreateHIT.R
+++ b/R/CreateHIT.R
@@ -302,6 +302,7 @@ CreateHIT <-
     # Validity check
     if(class(response) == "try-error") {
       warning("Invalid Request")
+      warning(response)
     } else {
       HITs <- emptydf(1, 3, c("HITTypeId", "HITId", "Valid"))
       HITs$HITTypeId <- response$HIT$HITTypeId


### PR DESCRIPTION
Should the do.call on line 299 fail, CreateHIT will now send a warning message with the full response object. The response object contains additional error information received from mTurk.

When running through some test cases for some code utilizing pyMturkR, I tried to create a HIT with invalid parameters. The error I received was:
    $ operator is invalid for atomic vectors

With this additional warning, I see the following in the console:
![error](https://github.com/cloudyr/pyMTurkR/assets/1661105/35f04d70-6739-48e5-a087-ca997fc335e7)

I ran ```R CMD check --as-cran``` on the package and it seems to build (aside from a latex error but I think I've seen that before on other successful cran packages I've checked).
